### PR TITLE
ENG-1826: Migrate Lambda runtime to provided.al2023

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_function" "xosphere_event_relay_lambda" {
   handler = "bootstrap"
   memory_size = 128
   role = var.event_relay_iam_role_arn
-  runtime = "provided.al2"
+  runtime = "provided.al2023"
   architectures = [ "arm64" ]
   timeout = 180
   tags = var.tags


### PR DESCRIPTION
AWS is ending support for the provided.al2 runtime on July 31, 2026. Update event relay Lambda to use provided.al2023 (Amazon Linux 2023).